### PR TITLE
fix: allow parsing any json string, not only array or dict

### DIFF
--- a/jsonutils.go
+++ b/jsonutils.go
@@ -665,8 +665,8 @@ func Parse(str []byte) (JSONObject, error) {
 			val = &JSONArray{}
 			i, e = val.parse(str, i)
 		default:
-			// val, i, e = parseJSONValue(str, i)
-			return nil, NewJSONError(str, i, "Invalid JSON string")
+			val, i, e = parseJSONValue(str, i)
+			// return nil, NewJSONError(str, i, "Invalid JSON string")
 		}
 		if e != nil {
 			return nil, e


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
允许Parse任意的json string，不仅是json array"[]" or disct("{}"