### PR TITLE
JSONInt结构体增加Float()float64函数

### DIFF
--- a/access.go
+++ b/access.go
@@ -380,6 +380,13 @@ func (this *JSONFloat) Float(keys ...string) (float64, error) {
 	return this.data, nil
 }
 
+func (this *JSONInt) Float(keys ...string) (float64, error) {
+	if len(keys) > 0 {
+		return 0.0, ErrOutOfKeyRange // fmt.Errorf("Out of key range: %s", keys)
+	}
+	return float64(this.data), nil
+}
+
 func (this *JSONString) Float(keys ...string) (float64, error) {
 	if len(keys) > 0 {
 		return 0.0, ErrOutOfKeyRange // fmt.Errorf("Out of key range: %s", keys)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
为JSONInt结构体增加Float()float64函数，使JSONInt实例可以直接将数据转换为float64类型