### PR TITLE
feature: allow unmarshal json string into []string

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -361,6 +361,15 @@ func (this *JSONString) unmarshalValue(val reflect.Value) error {
 		return this.unmarshalValue(val.Elem())
 	case reflect.Interface:
 		val.Set(reflect.ValueOf(this.data))
+	case reflect.Slice:
+		dataLen := 1
+		if val.Cap() < dataLen {
+			newVal := reflect.MakeSlice(val.Type(), dataLen, dataLen)
+			val.Set(newVal)
+		} else if val.Len() != dataLen {
+			val.SetLen(dataLen)
+		}
+		return this.unmarshalValue(val.Index(0))
 	default:
 		log.Errorf("JSONDict type mismatch: %s", val.Type())
 		return ErrTypeMismatch // fmt.Errorf("JSONString type mismatch: %s", val.Type())

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -421,3 +421,17 @@ func TestUnmarshalInterface(t *testing.T) {
 		}
 	})
 }
+
+func TestUnmarshalString2Array(t *testing.T) {
+	type sStruct struct {
+		Provider []string `json:"provider"`
+	}
+	json := NewDict()
+	json.Add(NewString("Aliyun"), "provider")
+	s := sStruct{}
+	err := json.Unmarshal(&s)
+	if err != nil {
+		t.Errorf("TestUnmarshalString2Array fail %s", err)
+	}
+	t.Logf("%s", s)
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：允许unmarshal json string into slice

举例：json: {"provider": "aliyun"}, struct: type Input struct { Provider []string},
json.Unmarshal(struct)结果为：{Provider:[Aliyun]}

/cc @yousong @ioito 
