### PR TITLE
feature: Faster Marshall and UnMarshall

### DIFF
--- a/access.go
+++ b/access.go
@@ -29,7 +29,7 @@ type JSONPair struct {
 }
 
 func NewDict(objs ...JSONPair) *JSONDict {
-	dict := JSONDict{data: make(map[string]JSONObject)}
+	dict := JSONDict{data: make(map[string]JSONObject, len(objs))}
 	for _, o := range objs {
 		dict.data[o.key] = o.val
 	}
@@ -37,7 +37,7 @@ func NewDict(objs ...JSONPair) *JSONDict {
 }
 
 func NewArray(objs ...JSONObject) *JSONArray {
-	arr := JSONArray{data: make([]JSONObject, 0)}
+	arr := JSONArray{data: make([]JSONObject, 0, len(objs))}
 	for _, o := range objs {
 		arr.data = append(arr.data, o)
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -84,15 +84,15 @@ func marshalStruct(val reflect.Value, info *reflectutils.SStructFieldInfo) JSONO
 }
 
 func struct2JSONPairs(val reflect.Value) []JSONPair {
-	objPairs := make([]JSONPair, 0)
 	fields := reflectutils.FetchStructFieldValueSet(val)
+	objPairs := make([]JSONPair, 0, len(fields))
 	for i := 0; i < len(fields); i += 1 {
 		jsonInfo := fields[i].Info
 		if jsonInfo.Ignore {
 			continue
 		}
 		key := jsonInfo.MarshalName()
-		val := marshalValue(fields[i].Value, &jsonInfo)
+		val := marshalValue(fields[i].Value, jsonInfo)
 		if val != nil && val != JSONNull {
 			objPair := JSONPair{key: key, val: val}
 			objPairs = append(objPairs, objPair)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Make Marshall and UnMarshall faster
This commit is based on PR: https://github.com/yunionio/pkg/pull/43

Specifying Cap in advance can avoid capacity expansion in NewDict and NewArray

本次优化是基于[PR](https://github.com/yunionio/pkg/pull/43)，并针对Marshall和UnMarshall写了简单且极端的基准测试：

##### 测试代码

```go
package jsonutils

import (
	"testing"
)

type JSON struct {
	Foo int
	Bar string
	Baz float64
}

var j JSON

func init() {
	j = JSON{
		Foo: 123,
		Bar: "benchmark",
		Baz: 123.456,
	}
}

func BenchmarkJsonutilsMarshall(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = Marshal(j)
	}
}

func BenchmarkJsonutilsUnmarshall(b *testing.B) {
	o := Marshal(j)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		j := JSON{}
		o.Unmarshal(&j)
	}
}
```

##### 测试结果

###### 修改前的版本

`jsonutils.Marshall`

```shell
go test -test.bench ^BenchmarkJsonutilsMarshall$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/jsonutils
BenchmarkJsonutilsMarshall-12             638269              1741 ns/op            1632 B/op         30 allocs/op
PASS
ok      yunion.io/x/jsonutils   1.696s
```

`jsonutils.Unmarshll`

```shell
go test -test.bench ^BenchmarkJsonutilsUnmarshall$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/jsonutils
BenchmarkJsonutilsUnmarshall-12           442549              2532 ns/op            1776 B/op         52 allocs/op
PASS
ok      yunion.io/x/jsonutils   1.275s
```

###### 修改后的版本

`jsonutils.Marhall`

```shell
go test -test.bench ^BenchmarkJsonutilsMarshall$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/jsonutils
BenchmarkJsonutilsMarshall-12            1000000              1017 ns/op             768 B/op         16 allocs/op
PASS
ok      yunion.io/x/jsonutils   1.740s
```

`jsonutils.Unmarshall`

```shell
go test -test.bench ^BenchmarkJsonutilsUnmarshall$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/jsonutils
BenchmarkJsonutilsUnmarshall-12           686614              1591 ns/op             792 B/op         31 allocs/op
PASS
ok      yunion.io/x/jsonutils   1.230s
```


