### PR TITLE
Bugfix/yousong parsestring

### DIFF
--- a/clone_test.go
+++ b/clone_test.go
@@ -84,8 +84,8 @@ func TestDeepCopyCompound(t *testing.T) {
 				t.Fatalf("must parse, got %s", err)
 			}
 			objC := DeepCopy(obj)
-			if !reflect.DeepEqual(obj, objC) {
-				t.Fatalf("want %s, got %s", obj.String(), objC.String())
+			if !obj.Equals(objC) {
+				t.Fatalf("want\n%s\n, got\n%s", obj.String(), objC.String())
 			}
 			switch v := objC.(type) {
 			case *JSONArray:
@@ -94,7 +94,7 @@ func TestDeepCopyCompound(t *testing.T) {
 			case *JSONDict:
 				v.Set("id", NewString("nobody"))
 			}
-			if reflect.DeepEqual(obj, objC) {
+			if obj.Equals(objC) {
 				t.Fatalf("not copied: %s", obj.String())
 			}
 		})

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -267,33 +267,26 @@ func parseJSONValue(str []byte, offset int) (JSONObject, int, error) {
 }
 
 func quoteString(str string) string {
-	var buffer bytes.Buffer
-	buffer.WriteByte('"')
+	buf := make([]byte, 0, len(str)+2)
+	buf = append(buf, '"')
 	for i := 0; i < len(str); i++ {
-		var escape byte = 0xff
-		switch str[i] {
+		switch c := str[i]; c {
 		case '"':
-			escape = '"'
+			buf = append(buf, '\\', '"')
 		case '\r':
-			escape = 'r'
+			buf = append(buf, '\\', 'r')
 		case '\n':
-			escape = 'n'
+			buf = append(buf, '\\', 'n')
 		case '\t':
-			escape = 't'
+			buf = append(buf, '\\', 't')
 		case '\\':
-			escape = '\\'
+			buf = append(buf, '\\', '\\')
 		default:
-			escape = 0xff
-		}
-		if escape != 0xff {
-			buffer.WriteByte('\\')
-			buffer.WriteByte(escape)
-		} else {
-			buffer.WriteByte(str[i])
+			buf = append(buf, c)
 		}
 	}
-	buffer.WriteByte('"')
-	return buffer.String()
+	buf = append(buf, '"')
+	return string(buf)
 }
 
 func (this *JSONString) String() string {

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -267,26 +267,27 @@ func parseJSONValue(str []byte, offset int) (JSONObject, int, error) {
 }
 
 func quoteString(str string) string {
-	buf := make([]byte, 0, len(str)+2)
-	buf = append(buf, '"')
+	sb := &strings.Builder{}
+	sb.Grow(len(str) + 2)
+	sb.WriteByte('"')
 	for i := 0; i < len(str); i++ {
 		switch c := str[i]; c {
 		case '"':
-			buf = append(buf, '\\', '"')
+			sb.Write([]byte{'\\', '"'})
 		case '\r':
-			buf = append(buf, '\\', 'r')
+			sb.Write([]byte{'\\', 'r'})
 		case '\n':
-			buf = append(buf, '\\', 'n')
+			sb.Write([]byte{'\\', 'n'})
 		case '\t':
-			buf = append(buf, '\\', 't')
+			sb.Write([]byte{'\\', 't'})
 		case '\\':
-			buf = append(buf, '\\', '\\')
+			sb.Write([]byte{'\\', '\\'})
 		default:
-			buf = append(buf, c)
+			sb.WriteByte(c)
 		}
 	}
-	buf = append(buf, '"')
-	return string(buf)
+	sb.WriteByte('"')
+	return sb.String()
 }
 
 func (this *JSONString) String() string {

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -460,14 +460,16 @@ func parseDict(str []byte, offset int) (map[string]JSONObject, int, error) {
 }
 
 func parseArray(str []byte, offset int) ([]JSONObject, int, error) {
-	var list = make([]JSONObject, 0)
 	if str[offset] != '[' {
-		return list, offset, NewJSONError(str, offset, "[ not found")
+		return nil, offset, NewJSONError(str, offset, "[ not found")
 	}
-	var i = offset + 1
-	var val JSONObject = nil
-	var e error = nil
-	var stop = false
+	var (
+		list []JSONObject
+		i    = offset + 1
+		val  JSONObject
+		e    error
+		stop bool
+	)
 	for !stop && i < len(str) {
 		i = skipEmpty(str, i)
 		if i >= len(str) {

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -217,8 +217,7 @@ ret:
 
 func parseString(str []byte, offset int) (string, bool, int, error) {
 	var (
-		buffer []byte
-		i      = offset
+		i = offset
 	)
 	if c := str[i]; c == '"' || c == '\'' {
 		r, newOfs, err := parseQuoteString(str, i+1, c)
@@ -230,11 +229,10 @@ ret2:
 		case ' ', ':', ',', '\t', '\n', '}', ']':
 			break ret2
 		default:
-			buffer = append(buffer, str[i])
 			i++
 		}
 	}
-	return string(buffer), false, i, nil
+	return string(str[offset:i]), false, i, nil
 }
 
 func parseJSONValue(str []byte, offset int) (JSONObject, int, error) {

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -16,7 +16,6 @@ package jsonutils
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"sort"
 	"strconv"
@@ -290,10 +289,6 @@ func quoteString(str string) string {
 	return sb.String()
 }
 
-func (this *JSONString) String() string {
-	return quoteString(this.data)
-}
-
 func jsonPrettyString(o JSONObject, level int) string {
 	var buffer bytes.Buffer
 	for i := 0; i < level; i++ {
@@ -319,20 +314,12 @@ func (this *JSONValue) parse(str []byte, offset int) (int, error) {
 	return 0, nil
 }
 
-func (this *JSONValue) String() string {
-	return "null"
-}
-
 func (this *JSONValue) PrettyString() string {
 	return this.String()
 }
 
 func (this *JSONValue) prettyString(level int) string {
 	return jsonPrettyString(this, level)
-}
-
-func (this *JSONInt) String() string {
-	return fmt.Sprintf("%d", this.data)
 }
 
 func (this *JSONInt) PrettyString() string {
@@ -347,10 +334,6 @@ func (this *JSONInt) Value() int64 {
 	return this.data
 }
 
-func (this *JSONFloat) String() string {
-	return fmt.Sprintf("%f", this.data)
-}
-
 func (this *JSONFloat) PrettyString() string {
 	return this.String()
 }
@@ -361,14 +344,6 @@ func (this *JSONFloat) prettyString(level int) string {
 
 func (this *JSONFloat) Value() float64 {
 	return this.data
-}
-
-func (this *JSONBool) String() string {
-	if this.data {
-		return "true"
-	} else {
-		return "false"
-	}
 }
 
 func (this *JSONBool) PrettyString() string {
@@ -524,24 +499,6 @@ func (this *JSONDict) SortedKeys() []string {
 	return keys
 }
 
-func (this *JSONDict) String() string {
-	var buffer bytes.Buffer
-	buffer.WriteByte('{')
-	var idx = 0
-	for _, k := range this.SortedKeys() {
-		v := this.data[k]
-		if idx > 0 {
-			buffer.WriteString(",")
-		}
-		buffer.WriteString(quoteString(k))
-		buffer.WriteByte(':')
-		buffer.WriteString(v.String())
-		idx++
-	}
-	buffer.WriteByte('}')
-	return buffer.String()
-}
-
 func (this *JSONDict) PrettyString() string {
 	return this.prettyString(0)
 }
@@ -596,19 +553,6 @@ func (this *JSONArray) parse(str []byte, offset int) (int, error) {
 		this.data = val
 	}
 	return i, errors.Wrap(e, "parseArray")
-}
-
-func (this *JSONArray) String() string {
-	var buffer bytes.Buffer
-	buffer.WriteByte('[')
-	for idx, v := range this.data {
-		if idx > 0 {
-			buffer.WriteString(",")
-		}
-		buffer.WriteString(v.String())
-	}
-	buffer.WriteByte(']')
-	return buffer.String()
 }
 
 func (this *JSONArray) PrettyString() string {

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -98,12 +98,14 @@ type JSONBool struct {
 }
 
 func skipEmpty(str []byte, offset int) int {
-	const (
-		EMPTYSTR = " \t\n\r"
-	)
 	i := offset
-	for i < len(str) && strings.IndexByte(EMPTYSTR, str[i]) >= 0 {
-		i++
+	for i < len(str) {
+		switch str[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+		default:
+			return i
+		}
 	}
 	return i
 }

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -31,6 +31,8 @@ type JSONObject interface {
 	gotypes.ISerializable
 
 	parse(str []byte, offset int) (int, error)
+	writeSource
+
 	// String() string
 	PrettyString() string
 	prettyString(level int) string

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -157,7 +157,6 @@ func parseString(str []byte, offset int) (string, bool, int, error) {
 		runebytes = make([]byte, 4)
 		runen     int
 		i         = offset
-		endstr    string
 		quote     bool
 		quotec    byte
 	)
@@ -169,8 +168,6 @@ func parseString(str []byte, offset int) (string, bool, int, error) {
 		i++
 		quote = true
 		quotec = '\''
-	} else {
-		endstr = " :,\t\n}]"
 	}
 ret:
 	for i < len(str) {
@@ -226,11 +223,14 @@ ret:
 				buffer = append(buffer, str[i])
 				i++
 			}
-		} else if strings.IndexByte(endstr, str[i]) >= 0 {
-			break ret
 		} else {
-			buffer = append(buffer, str[i])
-			i++
+			switch str[i] {
+			case ' ', ':', ',', '\t', '\n':
+				break ret
+			default:
+				buffer = append(buffer, str[i])
+				i++
+			}
 		}
 	}
 	return string(buffer), quote, i, nil

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -152,12 +152,14 @@ func hexstr2rune(str []byte) (rune, error) {
 }
 
 func parseString(str []byte, offset int) (string, bool, int, error) {
-	var buffer bytes.Buffer
-	var endstr string
-	var runebytes = make([]byte, 4)
-	var runen int
-	var i = offset
-	var quote bool = false
+	var (
+		buffer    []byte
+		endstr    string
+		runebytes = make([]byte, 4)
+		runen     int
+		i         = offset
+		quote     bool
+	)
 	if str[i] == '"' {
 		endstr = "\""
 		i++
@@ -184,7 +186,7 @@ func parseString(str []byte, offset int) (string, bool, int, error) {
 						return "", quote, i, NewJSONError(str, i, e.Error())
 					}
 					runen = utf8.EncodeRune(runebytes, r)
-					buffer.Write(runebytes[0:runen])
+					buffer = append(buffer, runebytes[0:runen]...)
 					i += 4
 				case 'x':
 					i++
@@ -195,19 +197,19 @@ func parseString(str []byte, offset int) (string, bool, int, error) {
 					if e != nil {
 						return "", quote, i, NewJSONError(str, i, e.Error())
 					}
-					buffer.WriteByte(b)
+					buffer = append(buffer, b)
 					i += 2
 				case 'n':
-					buffer.WriteByte('\n')
+					buffer = append(buffer, '\n')
 					i++
 				case 'r':
-					buffer.WriteByte('\r')
+					buffer = append(buffer, '\r')
 					i++
 				case 't':
-					buffer.WriteByte('\t')
+					buffer = append(buffer, '\t')
 					i++
 				default:
-					buffer.WriteByte(str[i])
+					buffer = append(buffer, str[i])
 					i++
 				}
 			} else {
@@ -219,11 +221,11 @@ func parseString(str []byte, offset int) (string, bool, int, error) {
 			}
 			break
 		} else {
-			buffer.WriteByte(str[i])
+			buffer = append(buffer, str[i])
 			i++
 		}
 	}
-	return buffer.String(), quote, i, nil
+	return string(buffer), quote, i, nil
 }
 
 func parseJSONValue(str []byte, offset int) (JSONObject, int, error) {

--- a/jsonutils_test.go
+++ b/jsonutils_test.go
@@ -110,3 +110,23 @@ func TestJSONParse(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkParseString(b *testing.B) {
+	cases := []struct {
+		name string
+		c    string
+	}{
+		{
+			name: "all",
+			c:    `{"abc": 12, "def": [1,2,"123",4.43], "ghi": "hahahah"}`,
+		},
+	}
+
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ParseString(c.c)
+			}
+		})
+	}
+}

--- a/jsonutils_test.go
+++ b/jsonutils_test.go
@@ -131,6 +131,29 @@ func BenchmarkParseString(b *testing.B) {
 	}
 }
 
+func Benchmark_quoteString(b *testing.B) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "no escape",
+			in:   "hello world",
+		},
+		{
+			name: "escape",
+			in:   "hello\nworld\r\t\\",
+		},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				quoteString(c.in)
+			}
+		})
+	}
+}
+
 func BenchmarkStringify(b *testing.B) {
 	cases := []struct {
 		name string

--- a/jsonutils_test.go
+++ b/jsonutils_test.go
@@ -130,3 +130,29 @@ func BenchmarkParseString(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkStringify(b *testing.B) {
+	cases := []struct {
+		name string
+		c    string
+		obj  JSONObject
+	}{
+		{
+			name: "all",
+			c:    `{"abc": 12, "def": [1,2,"123",4.43], "ghi": "hahahah"}`,
+		},
+	}
+	for _, c := range cases {
+		var err error
+		c.obj, err = ParseString(c.c)
+		if err != nil {
+			b.Fatalf("%s: bad case: %v", c.name, err)
+		}
+
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.obj.String()
+			}
+		})
+	}
+}

--- a/string.go
+++ b/string.go
@@ -1,8 +1,8 @@
 package jsonutils
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 )
 
 func (this *JSONString) String() string {
@@ -30,32 +30,13 @@ func (this *JSONBool) String() string {
 }
 
 func (this *JSONDict) String() string {
-	var buffer bytes.Buffer
-	buffer.WriteByte('{')
-	var idx = 0
-	for _, k := range this.SortedKeys() {
-		v := this.data[k]
-		if idx > 0 {
-			buffer.WriteString(",")
-		}
-		buffer.WriteString(quoteString(k))
-		buffer.WriteByte(':')
-		buffer.WriteString(v.String())
-		idx++
-	}
-	buffer.WriteByte('}')
-	return buffer.String()
+	sb := &strings.Builder{}
+	this.buildString(sb)
+	return sb.String()
 }
 
 func (this *JSONArray) String() string {
-	var buffer bytes.Buffer
-	buffer.WriteByte('[')
-	for idx, v := range this.data {
-		if idx > 0 {
-			buffer.WriteString(",")
-		}
-		buffer.WriteString(v.String())
-	}
-	buffer.WriteByte(']')
-	return buffer.String()
+	sb := &strings.Builder{}
+	this.buildString(sb)
+	return sb.String()
 }

--- a/string.go
+++ b/string.go
@@ -1,0 +1,61 @@
+package jsonutils
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func (this *JSONString) String() string {
+	return quoteString(this.data)
+}
+
+func (this *JSONValue) String() string {
+	return "null"
+}
+
+func (this *JSONInt) String() string {
+	return fmt.Sprintf("%d", this.data)
+}
+
+func (this *JSONFloat) String() string {
+	return fmt.Sprintf("%f", this.data)
+}
+
+func (this *JSONBool) String() string {
+	if this.data {
+		return "true"
+	} else {
+		return "false"
+	}
+}
+
+func (this *JSONDict) String() string {
+	var buffer bytes.Buffer
+	buffer.WriteByte('{')
+	var idx = 0
+	for _, k := range this.SortedKeys() {
+		v := this.data[k]
+		if idx > 0 {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString(quoteString(k))
+		buffer.WriteByte(':')
+		buffer.WriteString(v.String())
+		idx++
+	}
+	buffer.WriteByte('}')
+	return buffer.String()
+}
+
+func (this *JSONArray) String() string {
+	var buffer bytes.Buffer
+	buffer.WriteByte('[')
+	for idx, v := range this.data {
+		if idx > 0 {
+			buffer.WriteString(",")
+		}
+		buffer.WriteString(v.String())
+	}
+	buffer.WriteByte(']')
+	return buffer.String()
+}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -183,11 +183,15 @@ func TestMarshalPtr(t *testing.T) {
 	jsonStrNonNil := Marshal(ptrsNonNil).String()
 
 	// unmarshal nils to non nils should perform override, partial if the source is not FULL
-	jsonObjNil.Unmarshal(ptrsNonNil)
-	jsonObj2 := Marshal(ptrsNonNil)
-	jsonObj2Str := jsonObj2.String()
-	if jsonObj2Str != "{}" {
-		t.Errorf("unmarshal result should be {}, got %s", jsonObj2Str)
+	{
+		nils := *ptrsNonNil
+		pnils := &nils
+		jsonObjNil.Unmarshal(pnils)
+		jsonObj2 := Marshal(pnils)
+		jsonObj2Str := jsonObj2.String()
+		if jsonObj2Str != "{}" {
+			t.Errorf("unmarshal result should be {}, got %s", jsonObj2Str)
+		}
 	}
 
 	// unmarshal non nil str will restore correctly
@@ -201,9 +205,8 @@ func TestMarshalPtr(t *testing.T) {
 		if err != nil {
 			t.Errorf("unmarshal error: %s", err)
 		}
-		jsonStrAgain := Marshal(ptrs).String()
-		if jsonStrAgain != jsonStrNonNil {
-			t.Errorf("reverse failed: want %s, got %s", jsonStrNonNil, jsonStrAgain)
+		if !reflect.DeepEqual(ptrs, ptrsNonNil) {
+			t.Errorf("reverse failed: want\n%#v\ngot\n%#v", ptrsNonNil, ptrs)
 		}
 	}
 }
@@ -275,9 +278,8 @@ func TestJSONArrayUnmarshal(t *testing.T) {
 
 	dest := JSONArray{}
 	jsonArr.Unmarshal(&dest)
-	t.Logf("%s", dest)
-	if Marshal(dest).String() != s {
-		t.Errorf("TestJSONArrayUnmarshal errors")
+	if jsonArr1 := Marshal(dest); !jsonArr1.Equals(jsonArr) {
+		t.Errorf("json array unmarshal, want:\n%s\ngot:\n%s", jsonArr.String(), jsonArr1.String())
 	}
 }
 

--- a/write.go
+++ b/write.go
@@ -1,0 +1,57 @@
+package jsonutils
+
+import (
+	"strings"
+)
+
+type writeSource interface {
+	buildString(sb *strings.Builder)
+}
+
+func (this *JSONString) buildString(sb *strings.Builder) {
+	sb.WriteString(this.String())
+}
+
+func (this *JSONValue) buildString(sb *strings.Builder) {
+	sb.WriteString(this.String())
+}
+
+func (this *JSONInt) buildString(sb *strings.Builder) {
+	sb.WriteString(this.String())
+}
+
+func (this *JSONFloat) buildString(sb *strings.Builder) {
+	sb.WriteString(this.String())
+}
+
+func (this *JSONBool) buildString(sb *strings.Builder) {
+	sb.WriteString(this.String())
+}
+
+func (this *JSONDict) buildString(sb *strings.Builder) {
+	sb.WriteByte('{')
+	var idx = 0
+	for _, k := range this.SortedKeys() {
+		if idx > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(quoteString(k))
+		sb.WriteByte(':')
+
+		v := this.data[k]
+		v.buildString(sb)
+		idx++
+	}
+	sb.WriteByte('}')
+}
+
+func (this *JSONArray) buildString(sb *strings.Builder) {
+	sb.WriteByte('[')
+	for idx, v := range this.data {
+		if idx > 0 {
+			sb.WriteByte(',')
+		}
+		v.buildString(sb)
+	}
+	sb.WriteByte(']')
+}

--- a/write.go
+++ b/write.go
@@ -31,14 +31,13 @@ func (this *JSONBool) buildString(sb *strings.Builder) {
 func (this *JSONDict) buildString(sb *strings.Builder) {
 	sb.WriteByte('{')
 	var idx = 0
-	for _, k := range this.SortedKeys() {
+	for k, v := range this.data {
 		if idx > 0 {
 			sb.WriteByte(',')
 		}
 		sb.WriteString(quoteString(k))
 		sb.WriteByte(':')
 
-		v := this.data[k]
 		v.buildString(sb)
 		idx++
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

前后

    BenchmarkParseString/all-8                446190              2709 ns/op
    BenchmarkParseString/all-8                671238              1855 ns/op

    Benchmark_quoteString/no_escape-8                7003748               168 ns/op
    Benchmark_quoteString/escape-8                   5508367               213 ns/op
    Benchmark_quoteString/no_escape-8               14689308                81.5 ns/op
    Benchmark_quoteString/escape-8                   9267925               127 ns/op

    BenchmarkStringify/all-8                  536899              2343 ns/op
    BenchmarkStringify/all-8                  684812              1876 ns/op
    BenchmarkStringify/all-8                  761499              1613 ns/op
```
Add BenchmarkParseString
parseString: use slice instead of bytes.Buffer
parseString: quote in its own block
parseString: use switch case instead of strings.IndexByte
parseString: call separate parseQuoteString
parseString: eliminate slice alloc
skipEmpty: use switch case
parseArray: readability change
Add BenchmarkStringify
Add Benchmark_quoteString
quoteString: use byte slice
quoteString: use strings builder
move String() method to a separate file
stringify: use string builder
stringify: object: no sorted keys on default stringification
```

/cc @swordqiu @zexi @wanyaoqi @rainzm 