### PR TITLE
fix: preserve key order when output json dict

### DIFF
--- a/dict_test.go
+++ b/dict_test.go
@@ -15,6 +15,7 @@
 package jsonutils
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -49,5 +50,19 @@ func TestDiff(t *testing.T) {
 	}
 	if !aAndB.Contains("description") {
 		t.Errorf("a and b should contains description")
+	}
+}
+
+func TestDictKeyOrder(t *testing.T) {
+	dict := NewDict()
+	for i := 0; i < 26; i += 1 {
+		key := fmt.Sprintf("%c%c", 'A'+i, 'a'+i)
+		dict.Add(NewInt(int64(i)), key)
+	}
+	dictStr := dict.String()
+	for i := 0; i < 26; i += 1 {
+		if dict.String() != dictStr {
+			t.Fatalf("dict string changed!!!")
+		}
 	}
 }

--- a/write.go
+++ b/write.go
@@ -31,7 +31,8 @@ func (this *JSONBool) buildString(sb *strings.Builder) {
 func (this *JSONDict) buildString(sb *strings.Builder) {
 	sb.WriteByte('{')
 	var idx = 0
-	for k, v := range this.data {
+	for _, k := range this.SortedKeys() {
+		v := this.data[k]
 		if idx > 0 {
 			sb.WriteByte(',')
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
jsondict输出未对key排序，导致每次输出内容不一致 /cc @yousong 