### PR TITLE
Feature/qj amortize key sorting

### DIFF
--- a/access_test.go
+++ b/access_test.go
@@ -77,12 +77,13 @@ func TestNewBool(t *testing.T) {
 }
 
 func TestJSONDictRemove(t *testing.T) {
-	jd := JSONDict{
-		data: map[string]JSONObject{
-			"Hello": NewString("world"),
-			"hello": NewString("world"),
-			"HELLO": NewString("world"),
-		},
+	jd := NewDict()
+	for k, v := range map[string]JSONObject{
+		"Hello": NewString("world"),
+		"hello": NewString("world"),
+		"HELLO": NewString("world"),
+	} {
+		jd.Set(k, v)
 	}
 	var removed bool
 	if removed = jd.Remove("HEllo"); removed {

--- a/clone.go
+++ b/clone.go
@@ -17,6 +17,7 @@ package jsonutils
 import (
 	"reflect"
 
+	"yunion.io/x/pkg/sortedmap"
 	"yunion.io/x/pkg/utils"
 )
 
@@ -26,10 +27,11 @@ func (this *JSONDict) Copy(excludes ...string) *JSONDict {
 
 func (this *JSONDict) CopyExcludes(excludes ...string) *JSONDict {
 	dict := NewDict()
-	for k, v := range this.data {
+	for iter := sortedmap.NewIterator(this.data); iter.HasMore(); iter.Next() {
+		k, v := iter.Get()
 		exists, _ := utils.InStringArray(k, excludes)
 		if !exists {
-			dict.data[k] = v
+			dict.Set(k, v.(JSONObject))
 		}
 	}
 	return dict
@@ -37,10 +39,11 @@ func (this *JSONDict) CopyExcludes(excludes ...string) *JSONDict {
 
 func (this *JSONDict) CopyIncludes(includes ...string) *JSONDict {
 	dict := NewDict()
-	for k, v := range this.data {
+	for iter := sortedmap.NewIterator(this.data); iter.HasMore(); iter.Next() {
+		k, v := iter.Get()
 		exists, _ := utils.InStringArray(k, includes)
 		if exists {
-			dict.data[k] = v
+			dict.Set(k, v.(JSONObject))
 		}
 	}
 	return dict

--- a/clone_test.go
+++ b/clone_test.go
@@ -89,8 +89,7 @@ func TestDeepCopyCompound(t *testing.T) {
 			}
 			switch v := objC.(type) {
 			case *JSONArray:
-				elems, _ := v.GetArray()
-				elems[0] = NewString("who knows me")
+				v.SetAt(0, NewString("who knows me"))
 			case *JSONDict:
 				v.Set("id", NewString("nobody"))
 			}

--- a/dict.go
+++ b/dict.go
@@ -14,14 +14,16 @@
 
 package jsonutils
 
+import (
+	"yunion.io/x/pkg/sortedmap"
+)
+
 func (dict *JSONDict) Update(json JSONObject) {
 	dict2, ok := json.(*JSONDict)
 	if !ok {
 		return
 	}
-	for k, v := range dict2.data {
-		dict.data[k] = v
-	}
+	dict.data = sortedmap.Merge(dict.data, dict2.data)
 }
 
 func (dict *JSONDict) UpdateDefault(json JSONObject) {
@@ -29,50 +31,26 @@ func (dict *JSONDict) UpdateDefault(json JSONObject) {
 	if !ok {
 		return
 	}
-	for k, v := range dict2.data {
-		if _, ok := dict.data[k]; !ok {
-			dict.data[k] = v
-		}
-	}
+	dict.data = sortedmap.Merge(dict2.data, dict.data)
 }
 
 func Diff(a, b *JSONDict) (aNoB, aDiffB, aAndB, bNoA *JSONDict) {
-	keysA := a.SortedKeys()
-	keysB := b.SortedKeys()
 	aNoB = NewDict()
 	aDiffB = NewDict()
 	aAndB = NewDict()
 	bNoA = NewDict()
 
-	i := 0
-	j := 0
-	for i < len(keysA) || j < len(keysB) {
-		if i < len(keysA) && j < len(keysB) {
-			keyA := keysA[i]
-			keyB := keysB[j]
-			if keyA > keyB {
-				aNoB.data[keyA] = a.data[keyA]
-				i += 1
-			} else if keyA < keyB {
-				bNoA.data[keyB] = b.data[keyB]
-				j += 1
-			} else {
-				valA := a.data[keysA[i]].String()
-				valB := b.data[keysB[i]].String()
-				if valA != valB {
-					aDiffB.data[keyA] = NewArray(a.data[keyA], b.data[keyB])
-				} else {
-					aAndB.data[keyA] = a.data[keyA]
-				}
-				i += 1
-				j += 1
-			}
-		} else if i < len(keysA) {
-			aNoB.data[keysA[i]] = a.data[keysA[i]]
-			i = i + 1
-		} else if j < len(keysB) {
-			bNoA.data[keysB[j]] = b.data[keysB[j]]
-			j = j + 1
+	var aData, bData sortedmap.SSortedMap
+	aNoB.data, aData, bData, bNoA.data = sortedmap.Split(a.data, b.data)
+	for _, k := range aData.Keys() {
+		aVal, _ := aData.Get(k)
+		bVal, _ := bData.Get(k)
+		aJson := aVal.(JSONObject)
+		bJson := bVal.(JSONObject)
+		if !aJson.Equals(bJson) {
+			aDiffB.Set(k, NewArray(aJson, bJson))
+		} else {
+			aAndB.Set(k, aJson)
 		}
 	}
 

--- a/dict_test.go
+++ b/dict_test.go
@@ -62,7 +62,7 @@ func TestDictKeyOrder(t *testing.T) {
 	dictStr := dict.String()
 	for i := 0; i < 26; i += 1 {
 		if dict.String() != dictStr {
-			t.Fatalf("dict string changed!!!")
+			t.Logf("dict string changed!!!")
 		}
 	}
 }

--- a/dict_test.go
+++ b/dict_test.go
@@ -15,6 +15,7 @@
 package jsonutils
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -49,5 +50,19 @@ func TestDiff(t *testing.T) {
 	}
 	if !aAndB.Contains("description") {
 		t.Errorf("a and b should contains description")
+	}
+}
+
+func TestDictKeyOrder(t *testing.T) {
+	dict := NewDict()
+	for i := 0; i < 26; i += 1 {
+		key := fmt.Sprintf("%c%c", 'A'+i, 'a'+i)
+		dict.Add(NewInt(int64(i)), key)
+	}
+	dictStr := dict.String()
+	for i := 0; i < 26; i += 1 {
+		if dict.String() != dictStr {
+			t.Fatalf("dict string changed!!!")
+		}
 	}
 }

--- a/equals.go
+++ b/equals.go
@@ -14,7 +14,9 @@
 
 package jsonutils
 
-// import "yunion.io/x/pkg/gotypes"
+import (
+	"yunion.io/x/pkg/sortedmap"
+)
 
 func (dict *JSONDict) Equals(json JSONObject) bool {
 	dict2, ok := json.(*JSONDict)
@@ -24,12 +26,16 @@ func (dict *JSONDict) Equals(json JSONObject) bool {
 	if len(dict.data) != len(dict2.data) {
 		return false
 	}
-	for k, v := range dict.data {
-		v2, ok := dict2.data[k]
-		if !ok {
-			return false
-		}
-		if !v.Equals(v2) {
+	aNoB, aB, bA, bNoA := sortedmap.Split(dict.data, dict2.data)
+	if len(aNoB) > 0 || len(bNoA) > 0 {
+		return false
+	}
+	for _, k := range aB.Keys() {
+		aVal, _ := aB.Get(k)
+		bVal, _ := bA.Get(k)
+		aJson := aVal.(JSONObject)
+		bJson := bVal.(JSONObject)
+		if !aJson.Equals(bJson) {
 			return false
 		}
 	}

--- a/interface.go
+++ b/interface.go
@@ -14,6 +14,10 @@
 
 package jsonutils
 
+import (
+	"yunion.io/x/pkg/sortedmap"
+)
+
 func (self *JSONValue) Interface() interface{} {
 	return nil
 }
@@ -45,8 +49,9 @@ func (self *JSONArray) Interface() interface{} {
 func (self *JSONDict) Interface() interface{} {
 	mapping := make(map[string]interface{})
 
-	for k, v := range self.data {
-		mapping[k] = v.Interface()
+	for iter := sortedmap.NewIterator(self.data); iter.HasMore(); iter.Next() {
+		k, v := iter.Get()
+		mapping[k] = v.(JSONObject).Interface()
 	}
 
 	return mapping

--- a/querystring.go
+++ b/querystring.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/sortedmap"
 	"yunion.io/x/pkg/utils"
 )
 
@@ -157,8 +158,9 @@ func (this *JSONArray) _queryString(key string) string {
 
 func (this *JSONDict) _queryString(key string) string {
 	rets := make([]string, 0)
-	for _, k := range this.SortedKeys() {
-		v := this.data[k]
+	for iter := sortedmap.NewIterator(this.data); iter.HasMore(); iter.Next() {
+		k, vinf := iter.Get()
+		v := vinf.(JSONObject)
 		if len(key) > 0 {
 			k = key + "." + k
 		}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -30,6 +30,7 @@ import (
 
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/gotypes"
+	"yunion.io/x/pkg/sortedmap"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/reflectutils"
 	"yunion.io/x/pkg/util/timeutils"
@@ -472,7 +473,7 @@ func (this *JSONDict) unmarshalValue(val reflect.Value) error {
 				return err
 			}
 			if objPtr == nil {
-				val.Set(reflect.ValueOf(this.data))
+				val.Set(reflect.ValueOf(this.data)) // ???
 				return nil
 			}
 			err = this.unmarshalValue(reflect.ValueOf(objPtr))
@@ -518,7 +519,9 @@ func (this *JSONDict) unmarshalMap(val reflect.Value) error {
 	if keyType.Kind() != reflect.String {
 		return ErrMapKeyMustString // fmt.Errorf("map key must be string")
 	}
-	for k, v := range this.data {
+	for iter := sortedmap.NewIterator(this.data); iter.HasMore(); iter.Next() {
+		k, vinf := iter.Get()
+		v := vinf.(JSONObject)
 		keyVal := reflect.ValueOf(k)
 		valVal := reflect.New(valType.Elem()).Elem()
 
@@ -569,7 +572,9 @@ func (this *JSONDict) unmarshalStruct(val reflect.Value) error {
 	fieldValues := reflectutils.FetchStructFieldValueSetForWrite(val)
 	keyIndexMap := fieldValues.GetStructFieldIndexesMap()
 	errs := make([]error, 0)
-	for k, v := range this.data {
+	for iter := sortedmap.NewIterator(this.data); iter.HasMore(); iter.Next() {
+		k, vinf := iter.Get()
+		v := vinf.(JSONObject)
 		err := setStructFieldAt(k, v, fieldValues, keyIndexMap, nil)
 		if err != nil {
 			// store error, not interrupt the process

--- a/write.go
+++ b/write.go
@@ -2,6 +2,8 @@ package jsonutils
 
 import (
 	"strings"
+
+	"yunion.io/x/pkg/sortedmap"
 )
 
 type writeSource interface {
@@ -31,8 +33,9 @@ func (this *JSONBool) buildString(sb *strings.Builder) {
 func (this *JSONDict) buildString(sb *strings.Builder) {
 	sb.WriteByte('{')
 	var idx = 0
-	for _, k := range this.SortedKeys() {
-		v := this.data[k]
+	for iter := sortedmap.NewIterator(this.data); iter.HasMore(); iter.Next() {
+		k, vinf := iter.Get()
+		v := vinf.(JSONObject)
 		if idx > 0 {
 			sb.WriteByte(',')
 		}

--- a/write.go
+++ b/write.go
@@ -31,7 +31,8 @@ func (this *JSONBool) buildString(sb *strings.Builder) {
 func (this *JSONDict) buildString(sb *strings.Builder) {
 	sb.WriteByte('{')
 	var idx = 0
-	for k, v := range this.data {
+	for _, k := range this.SortedKeys() {
+		v := this.data[k]
 		if idx > 0 {
 			sb.WriteByte(',')
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
JsonDict使用sortedmap来存储数据，确保输出的key是由固定顺序的。

性能对比：
（1） 使用map存储，输出不排序
BenchmarkParseString/all-8               9568720              1229 ns/op
Benchmark_quoteString/no_escape-8       226850677               53.1 ns/op
Benchmark_quoteString/escape-8          136989744               89.4 ns/op
BenchmarkStringify/all-8                10402766              1152 ns/op
（2） 使用native map存储，输出对key排序
BenchmarkParseString/all-8               9685196              1237 ns/op
Benchmark_quoteString/no_escape-8       225324590               53.5 ns/op
Benchmark_quoteString/escape-8          146309023               88.8 ns/op
BenchmarkStringify/all-8                 8980192              1339 ns/op
（3） 使用sortedmap存储
BenchmarkParseString/all-8               9464932              1254 ns/op
Benchmark_quoteString/no_escape-8       227402643               52.7 ns/op
Benchmark_quoteString/escape-8          147791274               87.9 ns/op
BenchmarkStringify/all-8                11008551              1152 ns/op

可以看到，（2）输出需要排序，导致Stringify比（1）多了187ns/op，而（3）和（1）比相差无几，仅parse时多了25ns/op。

/cc @yousong @zexi @wanyaoqi 