### PR TITLE
fix: support unmarshal into map of none-string key

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -524,6 +524,9 @@ func (this *JSONDict) unmarshalMap(val reflect.Value) error {
 		k, vinf := iter.Get()
 		v := vinf.(JSONObject)
 		keyVal := reflect.ValueOf(k)
+		if keyType != keyVal.Type() {
+			keyVal = keyVal.Convert(keyType)
+		}
 		valVal := reflect.New(valType.Elem()).Elem()
 
 		err := v.unmarshalValue(valVal)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -462,7 +462,9 @@ func TestUnmarshalInterface(t *testing.T) {
 		metadata.Add(JSONTrue, "is_student")
 		metadata.Add(NewFloat(1.2), "weight")
 
-		meta := make(map[string]interface{}, 0)
+		type MapKeyType string
+
+		meta := make(map[MapKeyType]interface{}, 0)
 		err := metadata.Unmarshal(meta)
 		if err != nil {
 			t.Fatalf("Get VM Metadata error: %v", err)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：允许unmarshal key不是string类型的map