### PR TITLE
fix: encode specials chars as byte in json string

### DIFF
--- a/access_test.go
+++ b/access_test.go
@@ -105,32 +105,25 @@ func TestJSONDictRemove(t *testing.T) {
 
 func TestJSONSpecialChar(t *testing.T) {
 	cases := []struct {
-		in    string
-		equal bool
+		in string
 	}{
 		{
-			in:    string([]byte{'y', 'u', 'n', 'i', 'o', 'n', '\n'}),
-			equal: true,
+			in: string([]byte{'y', 'u', 'n', 'i', 'o', 'n', '\n'}),
 		},
 		{
-			in:    "中文Engilish\bok\n\t",
-			equal: false,
+			in: "中文Engilish\bok\n\t",
 		},
 		{
-			in:    string([]byte{'y', 'u', 'n', 'i', 'o', 'n', 10, 10, 10, 10}),
-			equal: true,
+			in: string([]byte{'y', 'u', 'n', 'i', 'o', 'n', 10, 10, 10, 10}),
 		},
 		{
-			in:    string([]byte{'y', 'u', 'n', 'i', 'o', 'n', 129, 10, 10, 10}),
-			equal: false,
+			in: string([]byte{'y', 'u', 'n', 'i', 'o', 'n', 129, 10, 10, 10}),
 		},
 		{
-			in:    string([]byte{'y', 'u', 'n', 'i', 'o', 'n', 8, 8, 8, 8}),
-			equal: false,
+			in: string([]byte{'y', 'u', 'n', 'i', 'o', 'n', 8, 8, 8, 8}),
 		},
 		{
-			in:    "中文 空格；符号。 中文：",
-			equal: true,
+			in: "中文 空格；符号。 中文：",
 		},
 	}
 	for _, c := range cases {
@@ -141,12 +134,12 @@ func TestJSONSpecialChar(t *testing.T) {
 		}
 		jd := Marshal(v)
 		output := jd.String()
-		t.Logf("output: %s", output)
+		t.Log("output: ", output)
 		newjd, err := ParseString(output)
 		if err != nil {
 			t.Errorf("ParseString %s fail: %s", output, err)
 		}
-		if newjd.Equals(jd) != c.equal {
+		if !newjd.Equals(jd) {
 			t.Errorf("newJd %s !=  jd %s", newjd, jd)
 		}
 		newStr, _ := newjd.GetString("common_name")

--- a/jsonutils.go
+++ b/jsonutils.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 	"unicode/utf8"
 
 	"yunion.io/x/pkg/errors"
@@ -202,6 +201,15 @@ ret:
 				case 't':
 					buffer = append(buffer, '\t')
 					i++
+				case 'b':
+					buffer = append(buffer, '\b')
+					i++
+				case 'f':
+					buffer = append(buffer, '\f')
+					i++
+				case '\\':
+					buffer = append(buffer, '\\')
+					i++
 				default:
 					buffer = append(buffer, str[i])
 					i++
@@ -269,40 +277,69 @@ func parseJSONValue(str []byte, offset int) (JSONObject, int, error) {
 	}
 }
 
+// https://www.ietf.org/rfc/rfc4627.txt
+//
+//         string = quotation-mark *char quotation-mark
+//
+//         char = unescaped /
+//                escape (
+//                    %x22 /          ; "    quotation mark  U+0022
+//                    %x5C /          ; \    reverse solidus U+005C
+//                    %x2F /          ; /    solidus         U+002F
+//                    %x62 /          ; b    backspace       U+0008
+//                    %x66 /          ; f    form feed       U+000C
+//                    %x6E /          ; n    line feed       U+000A
+//                    %x72 /          ; r    carriage return U+000D
+//                    %x74 /          ; t    tab             U+0009
+//                    %x75 4HEXDIG )  ; uXXXX                U+XXXX
+//
+//         escape = %x5C              ; \
+//
+//         quotation-mark = %x22      ; "
+//
+//         unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+//
+func escapeJsonChar(sb *strings.Builder, ch byte) {
+	switch ch {
+	case '"':
+		sb.Write([]byte{'\\', '"'})
+	case '\\':
+		sb.Write([]byte{'\\', '\\'})
+	case '\b':
+		sb.Write([]byte{'\\', 'b'})
+	case '\f':
+		sb.Write([]byte{'\\', 'f'})
+	case '\n':
+		sb.Write([]byte{'\\', 'n'})
+	case '\r':
+		sb.Write([]byte{'\\', 'r'})
+	case '\t':
+		sb.Write([]byte{'\\', 't'})
+	default:
+		sb.WriteByte(ch)
+		/*if ((ch >= 0x20 && ch <= 0x21) || (ch >= 0x23 || ch <= 0x5B) || (ch >= 0x5D && ch <= 0x10FFFF)) && ch != 0x81 && ch != 0x8d && ch != 0x8f && ch != 0x90 && ch != 0x9d {
+			sb.WriteRune(ch)
+		} else if ch <= 0xff {
+			sb.Write([]byte{'\\', 'x'})
+			sb.WriteString(fmt.Sprintf("%02x", ch))
+		} else if ch <= 0xffff {
+			sb.Write([]byte{'\\', 'u'})
+			sb.WriteString(fmt.Sprintf("%04x", ch))
+		} else {
+			sb.Write([]byte{'\\', 'u'})
+			sb.WriteString(fmt.Sprintf("%04x", ch>>16))
+			sb.Write([]byte{'\\', 'u'})
+			sb.WriteString(fmt.Sprintf("%04x", (ch & 0xffff)))
+		}*/
+	}
+}
+
 func quoteString(str string) string {
 	sb := &strings.Builder{}
 	sb.Grow(len(str) + 2)
 	sb.WriteByte('"')
-	for _, c := range str {
-		switch c {
-		case '"':
-			sb.Write([]byte{'\\', '"'})
-		case '\r':
-			sb.Write([]byte{'\\', 'r'})
-		case '\n':
-			sb.Write([]byte{'\\', 'n'})
-		case '\t':
-			sb.Write([]byte{'\\', 't'})
-		case '\\':
-			sb.Write([]byte{'\\', '\\'})
-		default:
-			if unicode.IsGraphic(c) {
-				sb.WriteRune(c)
-			}
-			// otherwise, ignore the character
-			/* else if c <= 0xff {
-				sb.Write([]byte{'\\', 'x'})
-				sb.WriteString(fmt.Sprintf("%02x", c))
-			} else if c <= 0xffff {
-				sb.Write([]byte{'\\', 'u'})
-				sb.WriteString(fmt.Sprintf("%04x", c))
-			} else {
-				sb.Write([]byte{'\\', 'u'})
-				sb.WriteString(fmt.Sprintf("%04x", c>>16))
-				sb.Write([]byte{'\\', 'u'})
-				sb.WriteString(fmt.Sprintf("%04x", (c & 0xffff)))
-			}*/
-		}
+	for i := 0; i < len(str); i += 1 {
+		escapeJsonChar(sb, str[i])
 	}
 	sb.WriteByte('"')
 	return sb.String()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：json字符串输出时，支持\b, \f等特殊控制字符，并且按照byte来输出，使得可以输出任意的binary string