### PR TITLE
fix: escape U+0000–U+001F in JSON strings as \uXXXX

### DIFF
--- a/jsonutils.go
+++ b/jsonutils.go
@@ -333,6 +333,12 @@ func escapeJsonChar(sb *strings.Builder, ch byte) {
 	case '\t':
 		sb.Write([]byte{'\\', 't'})
 	default:
+		// RFC 8259: U+0000–U+001F must be escaped as \uXXXX.
+		if ch < 0x20 {
+			const hexdigits = "0123456789abcdef"
+			sb.Write([]byte{'\\', 'u', '0', '0', hexdigits[ch>>4], hexdigits[ch&0xf]})
+			return
+		}
 		sb.WriteByte(ch)
 		/*if ((ch >= 0x20 && ch <= 0x21) || (ch >= 0x23 || ch <= 0x5B) || (ch >= 0x5D && ch <= 0x10FFFF)) && ch != 0x81 && ch != 0x8d && ch != 0x8f && ch != 0x90 && ch != 0x9d {
 			sb.WriteRune(ch)

--- a/jsonutils_test.go
+++ b/jsonutils_test.go
@@ -15,6 +15,8 @@
 package jsonutils
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -108,6 +110,51 @@ func TestJSONParse(t *testing.T) {
 		if got.String() != got2.String() {
 			t.Errorf("JSONParse: %s(%s) != %s(%s)", c.in, got, c.out, got2)
 		}
+	}
+}
+
+func TestQuoteStringControlChars(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "nul", in: "a\u0000b", want: `"a\u0000b"`},
+		{name: "soh", in: "x\u0001y", want: `"x\u0001y"`},
+		{name: "mixed_newline", in: "a\nb\u0000c", want: `"a\nb\u0000c"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := quoteString(c.in)
+			if got != c.want {
+				t.Fatalf("quoteString(%q) = %s, want %s", c.in, got, c.want)
+			}
+			if !json.Valid([]byte(got)) {
+				t.Fatalf("quoteString(%q) produced invalid JSON: %s", c.in, got)
+			}
+			if strings.Contains(got, "\x00") {
+				t.Fatalf("quoteString(%q) still contains raw NUL: %q", c.in, got)
+			}
+		})
+	}
+}
+
+func TestJSONStringControlCharRoundTrip(t *testing.T) {
+	src := "tool\u0000result\u0001ok\nnext"
+	wired := NewString(src).String()
+	if !json.Valid([]byte(wired)) {
+		t.Fatalf("NewString.String() invalid JSON: %s", wired)
+	}
+	parsed, err := ParseString(wired)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	var out string
+	if err := json.Unmarshal([]byte(parsed.String()), &out); err != nil {
+		t.Fatalf("json.Unmarshal after String(): %v (body=%s)", err, parsed.String())
+	}
+	if out != src {
+		t.Fatalf("round-trip mismatch: got %q want %q", out, src)
 	}
 }
 


### PR DESCRIPTION
RFC 8259 requires control characters to be escaped; raw NULs previously broke encoding/json consumers.

